### PR TITLE
Remove UUID constraint

### DIFF
--- a/aggregate/aggregate.go
+++ b/aggregate/aggregate.go
@@ -1,7 +1,6 @@
 package aggregate
 
 import (
-	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -9,11 +8,8 @@ import (
 	"github.com/hellofresh/goengine/metadata"
 )
 
-// ErrInvalidID occurs when a string is not a valid ID
-var ErrInvalidID = errors.New("goengine: an aggregate.ID must be a valid UUID")
-
 type (
-	// ID an UUID for a aggregate.Root instance
+	// ID for a aggregate.Root instance
 	ID string
 
 	// Root is a interface that a AggregateRoot must implement

--- a/aggregate/aggregate.go
+++ b/aggregate/aggregate.go
@@ -49,16 +49,6 @@ func GenerateID() ID {
 	return ID(uuid.New().String())
 }
 
-// IDFromString creates a ID from a string
-func IDFromString(str string) (ID, error) {
-	id, err := uuid.Parse(str)
-	if err != nil {
-		return "", ErrInvalidID
-	}
-
-	return ID(id.String()), nil
-}
-
 // RecordChange record the given event onto the aggregate.Root by wrapping it in an aggregate.Changed
 func RecordChange(aggregateRoot Root, event interface{}) error {
 	aggregateID := aggregateRoot.AggregateID()

--- a/aggregate/aggregate_test.go
+++ b/aggregate/aggregate_test.go
@@ -24,66 +24,6 @@ func TestGenerateID(t *testing.T) {
 	asserts.NotEqual(firstID, secondID, "Expected GenerateID() to return a different ID")
 }
 
-func TestIDFromString(t *testing.T) {
-	t.Run("valid uuid", func(t *testing.T) {
-		type uuidTestCase struct {
-			title  string
-			input  string
-			output aggregate.ID
-		}
-
-		testCases := []uuidTestCase{
-			{
-				"UUID",
-				"bf27f3c1-5fd6-4997-896a-63774ebd9ab0",
-				aggregate.ID("bf27f3c1-5fd6-4997-896a-63774ebd9ab0"),
-			},
-			{
-				"UUID with prefix",
-				"urn:uuid:f4ec75db-c0b0-4b00-a04f-a0d9ed18e9fb",
-				aggregate.ID("f4ec75db-c0b0-4b00-a04f-a0d9ed18e9fb"),
-			},
-		}
-
-		for _, testCase := range testCases {
-			t.Run(testCase.title, func(t *testing.T) {
-				id, err := aggregate.IDFromString(testCase.input)
-
-				assert.NoError(t, err)
-				assert.Equal(t, testCase.output, id)
-			})
-		}
-	})
-
-	t.Run("invalid uuid", func(t *testing.T) {
-		type invalidTestCase struct {
-			title string
-			input string
-		}
-
-		testCases := []invalidTestCase{
-			{
-				"some string",
-				"some string",
-			},
-			{
-				"UUID with missing minuses",
-				"f4ec75dbc0b04b00a04fa0d9ed18e9fb",
-			},
-		}
-
-		for _, testCase := range testCases {
-			t.Run(testCase.title, func(t *testing.T) {
-				id, err := aggregate.IDFromString(testCase.input)
-
-				asserts := assert.New(t)
-				asserts.Equal(aggregate.ErrInvalidID, err)
-				asserts.Equal(aggregate.ID(""), id)
-			})
-		}
-	})
-}
-
 func TestRecordChange(t *testing.T) {
 	t.Run("A change is recorded", func(t *testing.T) {
 		asserts := assert.New(t)

--- a/strategy/json/sql/message_factory_aggregate.go
+++ b/strategy/json/sql/message_factory_aggregate.go
@@ -120,7 +120,7 @@ func aggregateIDFromMetadata(meta metadata.Metadata) (aggregate.ID, error) {
 		return "", &InvalidMetadataValueTypeError{key: aggregate.IDKey, value: val, expected: "string"}
 	}
 
-	return aggregate.IDFromString(str)
+	return aggregate.ID(str), nil
 }
 
 func aggregateVersionFromMetadata(meta metadata.Metadata) (uint, error) {

--- a/test/projector_aggregate_integration_test.go
+++ b/test/projector_aggregate_integration_test.go
@@ -357,14 +357,10 @@ func (s *aggregateProjectorTestSuite) assertAggregateProjectionStates(expectedPr
 }
 
 func createAggregateIds(ids []string) []aggregate.ID {
-	var err error
 	res := make([]aggregate.ID, len(ids))
 
 	for i, id := range ids {
-		res[i], err = aggregate.IDFromString(id)
-		if err != nil {
-			panic(err)
-		}
+		res[i] = aggregate.ID(id)
 	}
 
 	return res


### PR DESCRIPTION
We want to verify if we can use GoEngine without assuming the aggregate ID has to be a UUID.
This PR removes the UUID constraint.