### PR TITLE
Add different databases support to the stream manager 

### DIFF
--- a/driver/sql/projector_aggregate.go
+++ b/driver/sql/projector_aggregate.go
@@ -66,7 +66,8 @@ func NewAggregateProjector(
 		return nil, err
 	}
 
-	executor, err := newNotificationProjector(
+	executor, err := NewNotificationProjector(
+		db,
 		db,
 		projectorStorage,
 		projection.Handlers(),

--- a/driver/sql/projector_stream.go
+++ b/driver/sql/projector_stream.go
@@ -25,7 +25,8 @@ type StreamProjector struct {
 
 // NewStreamProjector creates a new projector for a projection
 func NewStreamProjector(
-	db *sql.DB,
+	rdb *sql.DB,
+	wdb *sql.DB,
 	eventLoader EventStreamLoader,
 	resolver goengine.MessagePayloadResolver,
 	projection goengine.Projection,
@@ -34,7 +35,7 @@ func NewStreamProjector(
 	logger goengine.Logger,
 ) (*StreamProjector, error) {
 	switch {
-	case db == nil:
+	case rdb == nil:
 		return nil, goengine.InvalidArgumentError("db")
 	case eventLoader == nil:
 		return nil, goengine.InvalidArgumentError("eventLoader")
@@ -55,8 +56,9 @@ func NewStreamProjector(
 		e.String("projection", projection.Name())
 	})
 
-	executor, err := newNotificationProjector(
-		db,
+	executor, err := NewNotificationProjector(
+		rdb,
+		wdb,
 		projectorStorage,
 		projection.Handlers(),
 		eventLoader,
@@ -68,7 +70,7 @@ func NewStreamProjector(
 	}
 
 	return &StreamProjector{
-		db:                     db,
+		db:                     wdb,
 		executor:               executor,
 		storage:                projectorStorage,
 		projectionErrorHandler: projectionErrorHandler,

--- a/strategy/json/sql/postgres/manager.go
+++ b/strategy/json/sql/postgres/manager.go
@@ -25,7 +25,7 @@ type SingleStreamManager struct {
 // NewSingleStreamManager return a new instance of the SingleStreamManager
 func NewSingleStreamManager(db *sql.DB, logger goengine.Logger, metrics driverSQL.Metrics) (*SingleStreamManager, error) {
 	if db == nil {
-		return nil, goengine.InvalidArgumentError("db")
+		return nil, goengine.InvalidArgumentError("rdb")
 	}
 	if logger == nil {
 		logger = goengine.NopLogger
@@ -81,6 +81,7 @@ func (m *SingleStreamManager) PersistenceStrategy() driverSQL.PersistenceStrateg
 
 // NewStreamProjector returns a new stream projector instance
 func (m *SingleStreamManager) NewStreamProjector(
+	rdb *sql.DB,
 	projectionTable string,
 	projection goengine.Projection,
 	projectionErrorHandler driverSQL.ProjectionErrorCallback,
@@ -103,6 +104,7 @@ func (m *SingleStreamManager) NewStreamProjector(
 	}
 
 	return driverSQL.NewStreamProjector(
+		rdb,
 		m.db,
 		driverSQL.StreamProjectionEventStreamLoader(eventStore, projection.FromStream()),
 		m.payloadTransformer,


### PR DESCRIPTION
We were working on a project that has the projections database diffrent than the events stream database, so we created a  trigger to send notifications each time a new row is inserted in the event stream table. 

The problem was that, the current implementation of goengine only  supports one database. The `notificationProjector` was only operating on one database that has both the events table and projections table. 

We added a multi-stream manager `MultiStreamManager` to support having the events table and projections tables in two different databases. So now, we have both a `SingleStreamManager` (working with one database) and  a `MultiStreamManager`(working on two diffrent databases) that can be used depending on the use case.